### PR TITLE
Preventing screen from sleeping

### DIFF
--- a/Plugin/src/main/java/com/sonelli/juicessh/performancemonitor/activities/MainActivity.java
+++ b/Plugin/src/main/java/com/sonelli/juicessh/performancemonitor/activities/MainActivity.java
@@ -9,6 +9,7 @@ import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.Toast;
 
@@ -20,6 +21,7 @@ import com.sonelli.juicessh.performancemonitor.controllers.DiskUsageController;
 import com.sonelli.juicessh.performancemonitor.controllers.FreeRamController;
 import com.sonelli.juicessh.performancemonitor.controllers.LoadAverageController;
 import com.sonelli.juicessh.performancemonitor.controllers.NetworkUsageController;
+import com.sonelli.juicessh.performancemonitor.helpers.PreferenceHelper;
 import com.sonelli.juicessh.performancemonitor.loaders.ConnectionListLoader;
 import com.sonelli.juicessh.performancemonitor.views.AutoResizeTextView;
 import com.sonelli.juicessh.pluginlibrary.PluginClient;
@@ -68,6 +70,11 @@ public class MainActivity extends ActionBarActivity implements ActionBar.OnNavig
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        PreferenceHelper preferenceHelper = new PreferenceHelper(this);
+        if(preferenceHelper.getKeepScreenOnFlag()){
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
 
         // Create an adapter for populating the actionbar spinner with connections.
         // We're going to pass in TYPE_SSH to disable all spinner items not of this type.
@@ -206,6 +213,11 @@ public class MainActivity extends ActionBarActivity implements ActionBar.OnNavig
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.menu_main, menu);
+
+        // assigning the keep screen on menu the value of its saved status
+        PreferenceHelper preferenceHelper = new PreferenceHelper(this);
+        menu.findItem(R.id.keep_screen_on).setChecked(preferenceHelper.getKeepScreenOnFlag());
+
         return true;
     }
 
@@ -340,6 +352,17 @@ public class MainActivity extends ActionBarActivity implements ActionBar.OnNavig
                 Intent urlIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_url)));
                 urlIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
                 startActivity(Intent.createChooser(urlIntent, getString(R.string.open_address)));
+                return true;
+
+            case R.id.keep_screen_on:
+                item.setChecked(!item.isChecked());
+                PreferenceHelper preferenceHelper = new PreferenceHelper(this);
+                preferenceHelper.setKeepScreenOnFlag(item.isChecked());
+                if(item.isChecked()) {
+                    getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                }else{
+                    getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                }
                 return true;
 
             case R.id.rate_plugin:

--- a/Plugin/src/main/java/com/sonelli/juicessh/performancemonitor/helpers/PreferenceHelper.java
+++ b/Plugin/src/main/java/com/sonelli/juicessh/performancemonitor/helpers/PreferenceHelper.java
@@ -1,0 +1,29 @@
+package com.sonelli.juicessh.performancemonitor.helpers;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+public class PreferenceHelper {
+
+    private static final String KEEP_SCREEN_ON_KEY = "keep_screen_on_key";
+    private Context context;
+
+    public PreferenceHelper(Context context){
+        this.context = context;
+    }
+
+    public void setKeepScreenOnFlag(boolean flag) {
+        SharedPreferences sharedPreferences = PreferenceManager
+                .getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean(KEEP_SCREEN_ON_KEY, flag);
+        editor.commit();
+    }
+
+    public boolean getKeepScreenOnFlag() {
+        SharedPreferences sharedPreferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        return sharedPreferences.getBoolean(KEEP_SCREEN_ON_KEY, false);
+    }
+}

--- a/Plugin/src/main/res/layout/activity_main.xml
+++ b/Plugin/src/main/res/layout/activity_main.xml
@@ -3,7 +3,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity"
-    android:keepScreenOn="true"
     android:background="@android:color/black">
 
     <LinearLayout

--- a/Plugin/src/main/res/menu/menu_main.xml
+++ b/Plugin/src/main/res/menu/menu_main.xml
@@ -7,6 +7,12 @@
         android:orderInCategory="100"
         compat:showAsAction="never" />
 
+    <item android:id="@+id/keep_screen_on"
+        android:title="@string/keep_screen_on"
+        android:orderInCategory="100"
+        android:checkable="true"
+        compat:showAsAction="never" />
+
     <item android:id="@+id/rate_plugin"
         android:title="@string/rate_this_plugin"
         android:orderInCategory="100"

--- a/Plugin/src/main/res/values/strings.xml
+++ b/Plugin/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="rate_this_plugin">Rate this plugin</string>
     <string name="google_play_not_installed">Error: Google Play Store not installed</string>
     <string name="only_ssh_connections_are_supported">Only SSH connections are supported</string>
+    <string name="keep_screen_on">Keep screen on</string>
 </resources>


### PR DESCRIPTION
Preventing screen from sleeping when the plug-in using a switch in the menu. fixes issue #2. and doesn't require any extra permissions.
