### PR TITLE
Handle additional config changes to avoid activity restart

### DIFF
--- a/Plugin/src/main/AndroidManifest.xml
+++ b/Plugin/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:theme="@style/Theme.AppCompat.Light">
         <activity
             android:name=".activities.MainActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:configChanges="orientation|screenSize|keyboardHidden|keyboard|screenLayout|smallestScreenSize"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This fixes some annoying behavior I was seeing with my Pixel C on Nougat. When I would attach/detach the keyboard or adjust the size of the performance monitor window in multi-window mode, the activity would be destroyed and the connection would be lost.
