### PR TITLE
Handle attemping to select non-SSH connections correctly

### DIFF
--- a/Plugin/src/main/java/com/sonelli/juicessh/performancemonitor/activities/MainActivity.java
+++ b/Plugin/src/main/java/com/sonelli/juicessh/performancemonitor/activities/MainActivity.java
@@ -113,6 +113,12 @@ public class MainActivity extends AppCompatActivity implements ActionBar.OnNavig
             @Override
             public void onClick(View view) {
 
+                final int type = spinnerAdapter.getConnectionType(getSupportActionBar().getSelectedNavigationIndex());
+                if(type != PluginContract.Connections.TYPE_SSH) {
+                    Toast.makeText(MainActivity.this, MainActivity.this.getString(R.string.only_ssh_connections_are_supported), Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
                 final UUID id = spinnerAdapter.getConnectionId(getSupportActionBar().getSelectedNavigationIndex());
                 if(id != null){
                     if(isClientStarted){

--- a/Plugin/src/main/java/com/sonelli/juicessh/performancemonitor/adapters/ConnectionSpinnerAdapter.java
+++ b/Plugin/src/main/java/com/sonelli/juicessh/performancemonitor/adapters/ConnectionSpinnerAdapter.java
@@ -64,6 +64,28 @@ public class ConnectionSpinnerAdapter extends CursorAdapter {
 
     }
 
+    /**
+     * Returns the type of connection form the item at a given position, or -1 if not available
+     * @param position Position of the item to fetch the type of
+     * @return The connection type or -1 if it doesn't exist
+     */
+    public int getConnectionType(int position) {
+
+        int type = -1;
+
+        if(getCursor() != null){
+            if(getCursor().moveToPosition(position)) {
+                int typeIndex = getCursor().getColumnIndex(PluginContract.Connections.COLUMN_TYPE);
+                if (typeIndex > -1) {
+                    type = getCursor().getInt(typeIndex);
+                }
+            }
+        }
+
+        return type;
+
+    }
+
     @Override
     public boolean areAllItemsEnabled() {
         return false;
@@ -96,26 +118,10 @@ public class ConnectionSpinnerAdapter extends CursorAdapter {
             String name = cursor.getString(nameColumn);
             textView.setText(name);
 
-            // If the connection type != SSH (ie, it's a Mosh/telnet/local one)
-            // then disable the item in the list so that the plugin user cannot
-            // select it - as sending commands to non-ssh connections is not supported.
-
             if(type != -1){
                 if(cursor.getInt(typeColumn) != type){
-
-                    View.OnTouchListener listener = new View.OnTouchListener() {
-                        @Override
-                        public boolean onTouch(View view, MotionEvent motionEvent) {
-                            Toast.makeText(context, context.getString(R.string.only_ssh_connections_are_supported), Toast.LENGTH_SHORT).show();
-                            return false;
-                        }
-                    };
-
-                    textView.setOnTouchListener(listener);
                     textView.setTextColor(context.getResources().getColor(android.R.color.tab_indicator_text));
-
                 } else {
-                    textView.setOnTouchListener(null);
                     textView.setTextColor(context.getResources().getColor(android.R.color.black));
                 }
             }


### PR DESCRIPTION
The existing mechanism for preventing users from selecting a non-SSH connection doesn't actually prevent the selection. It also fires and displays a warning when tapping the spinner to create the drop-down menu if a non-SSH connection is the first option in the list. If a user does attempt to start a connection with a non-SSH target, the app will display endless error toasts until it is killed.

This change triggers the non-SSH connection warning on connect instead, which allows it to really prevent the connection from taking place.